### PR TITLE
커피 메뉴 카테고리 기능

### DIFF
--- a/src/app/(public)/(menu)/page.tsx
+++ b/src/app/(public)/(menu)/page.tsx
@@ -1,22 +1,13 @@
-import {
-  dehydrate,
-  QueryClient,
-  HydrationBoundary,
-} from "@tanstack/react-query";
-
 import MenuContainer from "@/feature/menu/ui/MenuContainer";
-import { prefetchMenuListAtServer } from "@/feature/menu/model/query/queries.server";
 
-const MenuPage = async () => {
-  const qc = new QueryClient();
-  await prefetchMenuListAtServer(qc);
-  const state = dehydrate(qc);
+interface MenuPageProps {
+  searchParams: Promise<{ categoryId?: string }>;
+}
 
-  return (
-    <HydrationBoundary state={state}>
-      <MenuContainer />
-    </HydrationBoundary>
-  );
+const MenuPage = async ({ searchParams }: MenuPageProps) => {
+  const { categoryId } = await searchParams;
+
+  return <MenuContainer categoryId={categoryId} />;
 };
 
 export default MenuPage;

--- a/src/app/(public)/(menu)/page.tsx
+++ b/src/app/(public)/(menu)/page.tsx
@@ -1,4 +1,5 @@
 import MenuContainer from "@/feature/menu/ui/MenuContainer";
+import { parseCategoryIdParams } from "@/shared/lib/category/validation";
 
 interface MenuPageProps {
   searchParams: Promise<{ categoryId?: string }>;
@@ -6,8 +7,9 @@ interface MenuPageProps {
 
 const MenuPage = async ({ searchParams }: MenuPageProps) => {
   const { categoryId } = await searchParams;
+  const parsedCateId = parseCategoryIdParams(categoryId);
 
-  return <MenuContainer categoryId={categoryId} />;
+  return <MenuContainer categoryId={parsedCateId} />;
 };
 
 export default MenuPage;

--- a/src/app/(public)/(menu)/page.tsx
+++ b/src/app/(public)/(menu)/page.tsx
@@ -1,4 +1,4 @@
-import MenuContainer from "@/feature/menu/ui/MenuContainer";
+import MenuSection from "@/widget/menu/ui/MenuSection";
 import { parseCategoryIdParams } from "@/shared/lib/category/validation";
 
 interface MenuPageProps {
@@ -9,7 +9,7 @@ const MenuPage = async ({ searchParams }: MenuPageProps) => {
   const { categoryId } = await searchParams;
   const parsedCateId = parseCategoryIdParams(categoryId);
 
-  return <MenuContainer categoryId={parsedCateId} />;
+  return <MenuSection categoryId={parsedCateId} />;
 };
 
 export default MenuPage;

--- a/src/feature/category/api/dto.ts
+++ b/src/feature/category/api/dto.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 
 /** 카테고리 리스트 요청 스키마 */
-export const getCategoryListReqDtoSchema = z.object({
-  id: z.number().optional(),
-});
+export const getCategoryListReqDtoSchema = z.object({});
 
 export type GetCategoryListReqDto = z.infer<typeof getCategoryListReqDtoSchema>;
 

--- a/src/feature/category/api/dto.ts
+++ b/src/feature/category/api/dto.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+/** 카테고리 리스트 요청 스키마 */
+export const getCategoryListReqDtoSchema = z.object({
+  id: z.number().optional(),
+});
+
+export type GetCategoryListReqDto = z.infer<typeof getCategoryListReqDtoSchema>;
+
+/** 카테고리 리스트 응답 스키마 */
+export const getCategoryListResDtoSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  value: z.string(),
+  sort_order: z.number(),
+  is_active: z.boolean(),
+});
+
+export type GetCategoryListResDto = z.infer<typeof getCategoryListResDtoSchema>;

--- a/src/feature/category/api/service.server.ts
+++ b/src/feature/category/api/service.server.ts
@@ -1,0 +1,14 @@
+import { GetCategoryListResDto } from "@/feature/category/api/dto";
+
+import { getServerClient } from "@/shared/config/supabase/server";
+
+export const getCategoryList = async (): Promise<GetCategoryListResDto[]> => {
+  const supabase = await getServerClient();
+  const { data, error } = await supabase
+    .from("categories")
+    .select("id, name, value, sort_order, is_active")
+    .order("sort_order", { ascending: true });
+
+  if (error) throw error;
+  return data ?? [];
+};

--- a/src/feature/category/model/mapper/index.ts
+++ b/src/feature/category/model/mapper/index.ts
@@ -1,0 +1,14 @@
+import { Category } from "@/feature/category/model/types";
+import { GetCategoryListResDto } from "@/feature/category/api/dto";
+
+export const categoryDtoToType = (data: GetCategoryListResDto): Category =>
+  ({
+    id: data.id,
+    name: data.name,
+    value: data.value,
+    sortOrder: data.sort_order,
+    isActive: data.is_active,
+  } satisfies Category);
+
+export const arrDtoToArrType = (data: GetCategoryListResDto[]): Category[] =>
+  data.map(categoryDtoToType);

--- a/src/feature/category/model/types.ts
+++ b/src/feature/category/model/types.ts
@@ -1,0 +1,7 @@
+export type Category = {
+  id: number;
+  name: string;
+  value: string;
+  sortOrder: number;
+  isActive: boolean;
+};

--- a/src/feature/category/ui/CategoryTab.tsx
+++ b/src/feature/category/ui/CategoryTab.tsx
@@ -1,0 +1,41 @@
+import { Category } from "@/feature/category/model/types";
+import { arrDtoToArrType } from "@/feature/category/model/mapper";
+import CategoryTabItem from "@/feature/category/ui/CategoryTabItem";
+import { getCategoryList } from "@/feature/category/api/service.server";
+
+import { isEmpty } from "@/shared/utils";
+
+interface CategoryTabProps {
+  selectedCategoryId: number | null;
+}
+
+const CategoryTab = async ({ selectedCategoryId }: CategoryTabProps) => {
+  const categoryList = await getCategoryList();
+  const categories: Category[] = arrDtoToArrType(categoryList);
+
+  if (isEmpty(categories)) return null;
+
+  // [전체] 탭 선택
+  const isAllSelected = selectedCategoryId === 0 || selectedCategoryId === null;
+
+  return (
+    <div
+      className="w-full px-3 md:justify-center justify-start flex gap-4 overflow-x-scroll whitespace-nowrap"
+      style={{ scrollbarWidth: "none" }}
+    >
+      <CategoryTabItem href={`?categoryId=${0}`} active={isAllSelected}>
+        전체
+      </CategoryTabItem>
+      {categories.map((c) => {
+        const isSelected = c.id === selectedCategoryId;
+        return (
+          <CategoryTabItem href={`?categoryId=${c.id}`} active={isSelected}>
+            {c.name}
+          </CategoryTabItem>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CategoryTab;

--- a/src/feature/category/ui/CategoryTab.tsx
+++ b/src/feature/category/ui/CategoryTab.tsx
@@ -6,7 +6,7 @@ import { getCategoryList } from "@/feature/category/api/service.server";
 import { isEmpty } from "@/shared/utils";
 
 interface CategoryTabProps {
-  selectedCategoryId: number | null;
+  selectedCategoryId?: number;
 }
 
 const CategoryTab = async ({ selectedCategoryId }: CategoryTabProps) => {
@@ -16,20 +16,24 @@ const CategoryTab = async ({ selectedCategoryId }: CategoryTabProps) => {
   if (isEmpty(categories)) return null;
 
   // [전체] 탭 선택
-  const isAllSelected = selectedCategoryId === 0 || selectedCategoryId === null;
+  const isAllSelected = !selectedCategoryId;
 
   return (
     <div
       className="w-full px-3 md:justify-center justify-start flex gap-4 overflow-x-scroll whitespace-nowrap"
       style={{ scrollbarWidth: "none" }}
     >
-      <CategoryTabItem href={`?categoryId=${0}`} active={isAllSelected}>
+      <CategoryTabItem href="?" active={isAllSelected}>
         전체
       </CategoryTabItem>
       {categories.map((c) => {
         const isSelected = c.id === selectedCategoryId;
         return (
-          <CategoryTabItem href={`?categoryId=${c.id}`} active={isSelected}>
+          <CategoryTabItem
+            key={c.id}
+            href={`?categoryId=${c.id}`}
+            active={isSelected}
+          >
             {c.name}
           </CategoryTabItem>
         );

--- a/src/feature/category/ui/CategoryTabItem.tsx
+++ b/src/feature/category/ui/CategoryTabItem.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+import { cn } from "@/shared/lib/cn";
+
+interface CategoryTabItemProps {
+  href: string;
+  active: boolean;
+  children: React.ReactNode;
+}
+const CategoryTabItem = ({ href, active, children }: CategoryTabItemProps) => {
+  return (
+    <Link
+      href={href}
+      prefetch
+      aria-pressed={active}
+      className={cn(
+        "px-2 py-1 cursor-pointer text-center font-semibold text-base pt-1",
+        active ? "bg-sky-300 rounded-2xl dark:bg-sky-500" : "bg-none"
+      )}
+    >
+      {children}
+    </Link>
+  );
+};
+
+export default CategoryTabItem;

--- a/src/feature/menu/api/dto.ts
+++ b/src/feature/menu/api/dto.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 /** 메뉴 리스트 요청 스키마 */
 export const getMenuListReqDtoSchema = z.object({
   name: z.string().optional(),
+  categoryId: z.number().optional(),
 });
 
 export type GetMenuListReqDto = z.infer<typeof getMenuListReqDtoSchema>;

--- a/src/feature/menu/api/service.server.ts
+++ b/src/feature/menu/api/service.server.ts
@@ -11,7 +11,10 @@ export async function getMenuListAtServer(
   params?: GetMenuListReqDto
 ): Promise<GetMenuListResDto[]> {
   const supabase = await getServerClient();
+
   const name = params?.name?.trim();
+  const categoryId = params?.categoryId;
+
   let query = supabase
     .from("menus")
     .select(
@@ -22,6 +25,10 @@ export async function getMenuListAtServer(
   if (name) {
     const pattern = `%${name.replace(/[%_]/g, "\\$&")}%`;
     query = query.ilike("name", pattern);
+  }
+
+  if (categoryId) {
+    query = query.eq("category_id", categoryId);
   }
 
   const { data, error } = await query;

--- a/src/feature/menu/api/service.ts
+++ b/src/feature/menu/api/service.ts
@@ -18,7 +18,7 @@ export const getMenuList = async (
     .order("id", { ascending: true });
 
   if (name) {
-    const pattern = `%${name.trim().replace(/[%_]/g, "\\$&")}%`;
+    const pattern = `%${name.replace(/[%_]/g, "\\$&")}%`;
     query = query.ilike("name", pattern);
   }
 

--- a/src/feature/menu/api/service.ts
+++ b/src/feature/menu/api/service.ts
@@ -5,7 +5,8 @@ import { getBrowserClient } from "@/shared/config/supabase/client";
 export const getMenuList = async (
   params?: GetMenuListReqDto
 ): Promise<GetMenuListResDto[]> => {
-  const { name } = params || {};
+  const name = params?.name?.trim();
+  const categoryId = params?.categoryId;
 
   const supabase = getBrowserClient();
 
@@ -16,10 +17,13 @@ export const getMenuList = async (
     )
     .order("id", { ascending: true });
 
-  // Like 검색 조건 -> 메뉴명(name)
-  if (name && name.trim()) {
+  if (name) {
     const pattern = `%${name.trim().replace(/[%_]/g, "\\$&")}%`;
     query = query.ilike("name", pattern);
+  }
+
+  if (categoryId) {
+    query = query.eq("category_id", categoryId);
   }
 
   const { data, error } = await query;

--- a/src/feature/menu/model/query/keys.ts
+++ b/src/feature/menu/model/query/keys.ts
@@ -4,5 +4,5 @@ export const menuKeys = {
   all: ["menu"] as const,
   list: () => [...menuKeys.all, "list"] as const,
   listWithParams: (params: GetMenuListReqDto) =>
-    [...menuKeys.list(), params.name ?? ""] as const,
+    [...menuKeys.list(), params] as const,
 };

--- a/src/feature/menu/ui/MenuContainer.tsx
+++ b/src/feature/menu/ui/MenuContainer.tsx
@@ -1,11 +1,17 @@
 import MenuList from "@/feature/menu/ui/MenuList";
+import CategoryTab from "@/feature/category/ui/CategoryTab";
+interface MenuContainerProps {
+  categoryId?: string;
+}
 
-const MenuContainer = () => {
+const MenuContainer = ({ categoryId }: MenuContainerProps) => {
   return (
-    <>
-      {/* <CategoryBar /> */}
-      <MenuList />
-    </>
+    <div className="flex flex-col gap-4 m-2">
+      <CategoryTab
+        selectedCategoryId={categoryId ? Number(categoryId) : null}
+      />
+      <MenuList categoryId={categoryId} />
+    </div>
   );
 };
 

--- a/src/feature/menu/ui/MenuContainer.tsx
+++ b/src/feature/menu/ui/MenuContainer.tsx
@@ -1,15 +1,14 @@
 import MenuList from "@/feature/menu/ui/MenuList";
 import CategoryTab from "@/feature/category/ui/CategoryTab";
+
 interface MenuContainerProps {
-  categoryId?: string;
+  categoryId?: number;
 }
 
 const MenuContainer = ({ categoryId }: MenuContainerProps) => {
   return (
     <div className="flex flex-col gap-4 m-2">
-      <CategoryTab
-        selectedCategoryId={categoryId ? Number(categoryId) : null}
-      />
+      <CategoryTab selectedCategoryId={categoryId} />
       <MenuList categoryId={categoryId} />
     </div>
   );

--- a/src/feature/menu/ui/MenuList.tsx
+++ b/src/feature/menu/ui/MenuList.tsx
@@ -9,13 +9,11 @@ import { getMenuListAtServer } from "@/feature/menu/api/service.server";
 import { isEmpty } from "@/shared/utils/isEmpty";
 
 interface MenuListProps {
-  categoryId?: string;
+  categoryId?: number;
 }
 
 const MenuList = async ({ categoryId }: MenuListProps) => {
-  const result = await getMenuListAtServer({
-    categoryId: categoryId ? Number(categoryId) : undefined,
-  });
+  const result = await getMenuListAtServer({ categoryId });
   const menus: Menu[] = arrDtoToArrType(result);
 
   if (isEmpty(menus)) {

--- a/src/feature/menu/ui/MenuList.tsx
+++ b/src/feature/menu/ui/MenuList.tsx
@@ -6,11 +6,19 @@ import { arrDtoToArrType } from "@/feature/menu/model/mapper";
 import MenuBuyButtons from "@/feature/menu/ui/MenuBuyButtons";
 import { getMenuListAtServer } from "@/feature/menu/api/service.server";
 
-const MenuList = async () => {
-  const dto = await getMenuListAtServer();
-  const menus: Menu[] = arrDtoToArrType(dto);
+import { isEmpty } from "@/shared/utils/isEmpty";
 
-  if (!menus.length) {
+interface MenuListProps {
+  categoryId?: string;
+}
+
+const MenuList = async ({ categoryId }: MenuListProps) => {
+  const result = await getMenuListAtServer({
+    categoryId: categoryId ? Number(categoryId) : undefined,
+  });
+  const menus: Menu[] = arrDtoToArrType(result);
+
+  if (isEmpty(menus)) {
     return (
       <main className="flex flex-col justify-center items-center h-full">
         <section className="w-full h-32 justify-center flex items-center text-4xl text-gray-400 opacity-70 font-[BitBit]">

--- a/src/shared/lib/category/validation.ts
+++ b/src/shared/lib/category/validation.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const categoryParamsValidationSchema = z.object({
+  categoryId: z.string().regex(/^\d+$/).optional(),
+});
+
+export const parseCategoryIdParams = (
+  categoryId: string | undefined
+): number | undefined => {
+  const { success, data } = categoryParamsValidationSchema.safeParse({
+    categoryId,
+  });
+  if (!success || !data.categoryId) return undefined;
+
+  const id = Number(data.categoryId);
+  return Number.isInteger(id) && id > 0 ? id : undefined;
+};

--- a/src/shared/utils/index.tsx
+++ b/src/shared/utils/index.tsx
@@ -1,0 +1,1 @@
+export * from "./isEmpty";

--- a/src/shared/utils/isEmpty.tsx
+++ b/src/shared/utils/isEmpty.tsx
@@ -1,0 +1,11 @@
+/**
+ * 배열/객체가 비어있는지 확인하는 유틸
+ * @param value
+ * @returns boolean
+ */
+export const isEmpty = (value: unknown): boolean => {
+  if (Array.isArray(value)) return value.length === 0;
+  if (value && typeof value === "object")
+    return Object.keys(value).length === 0;
+  return !value;
+};

--- a/src/widget/menu/ui/MenuSection.tsx
+++ b/src/widget/menu/ui/MenuSection.tsx
@@ -1,11 +1,11 @@
 import MenuList from "@/feature/menu/ui/MenuList";
 import CategoryTab from "@/feature/category/ui/CategoryTab";
 
-interface MenuContainerProps {
+interface MenuSectionProps {
   categoryId?: number;
 }
 
-const MenuContainer = ({ categoryId }: MenuContainerProps) => {
+const MenuSection = ({ categoryId }: MenuSectionProps) => {
   return (
     <div className="flex flex-col gap-4 m-2">
       <CategoryTab selectedCategoryId={categoryId} />
@@ -14,4 +14,4 @@ const MenuContainer = ({ categoryId }: MenuContainerProps) => {
   );
 };
 
-export default MenuContainer;
+export default MenuSection;


### PR DESCRIPTION
## Description

### 카테고리 선택 기능 추가
- `getMenuListAtServer` 함수가 `categoryId` 파라미터를 받도록 설정, 선택한 카테고리에 따른 메뉴를 fetch.
- `categoryId` 를 query parameter로 관리, 이를 파싱해 number 형의 id 혹은 undefined를 반환하는 `parseCategoryIdParams` 함수 생성.

### 메뉴 섹션
- 카테고리 탭 + 메뉴 리스트로 구성된 `MenuSection.tsx` 을 widget으로 이동(기존 `MenuContainer`). menu page에서 import해 사용.